### PR TITLE
Fix Tweet Button

### DIFF
--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ echo $output;
 </form>
 <btn>
 <button class="cp" Onclick="Clipboard()">コピー</button>
-<a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="<?php echo mb_strimwidth("$output", 0, 239, "…", 'UTF-8'); ?>" data-hashtags="怪レい日本語Web" data-show-count="false">Tweet</a><script async="" src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="<?php echo htmlspecialchars(mb_strimwidth("$output", 0, 239, "…", 'UTF-8'), ENT_QUOTES, "UTF-8"); ?>" data-hashtags="怪レい日本語Web" data-show-count="false">Tweet</a><script async="" src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </btn>
 </div>
 <script>

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ echo $output;
 </form>
 <btn>
 <button class="cp" Onclick="Clipboard()">コピー</button>
-<a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="<?php echo $output; ?>" data-hashtags="怪レい日本語Web" data-show-count="false">Tweet</a><script async="" src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="<?php echo mb_strimwidth("$output", 0, 239, "…", 'UTF-8'); ?>" data-hashtags="怪レい日本語Web" data-show-count="false">Tweet</a><script async="" src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </btn>
 </div>
 <script>


### PR DESCRIPTION
Twitterの文字数制限を回避して、
かつ文字列が長すぎる時に発生するHTTP 414/431エラーを回避する。
また、文字列をエスケープするように変更。
なぜなら文章に`<a href="https://example.com">Example</a>`などが含まれているとバグが発生するので、それを回避するため。
_このPR(プルリクエスト)はGoogle 翻訳によって日本語から英語に翻訳されました。_

Avoid the Twitter character limit,
And avoid HTTP 414/431 errors that occur when strings are too long.
Also changed to escape strings.
Because a bug occurs if the text contains `<a href="https://example.com">Example</a>` etc, to avoid it.
_This PR(pull request) was translated from Japanese to English by Google Translate._